### PR TITLE
Fix blockquote style

### DIFF
--- a/vue.css
+++ b/vue.css
@@ -494,7 +494,7 @@ ol:last-child {
 
 blockquote {
     border-left: 4px solid #42b983;
-    padding: 10px 0 10px 15px;
+    padding: 10px 15px;
     color: #777;
     background-color: rgba(66, 185, 131, .1);
 }


### PR DESCRIPTION
On a text is align right and it in blockquote
It is close to blockquote's right border
Now, I add padding-right to blockquote

Before Fix:
![old](https://user-images.githubusercontent.com/20502666/50405211-2d961e80-07ec-11e9-972e-a663349c8354.png)

After Fix:
![new](https://user-images.githubusercontent.com/20502666/50405218-3b4ba400-07ec-11e9-8750-6ee4ff970f80.png)
