### PR TITLE
Fixed ordered list line indention bug.

### DIFF
--- a/vue.css
+++ b/vue.css
@@ -281,7 +281,7 @@ body {
 }
 
 #write ol li {
-    text-indent: 0.5rem;
+    padding-left: 0.5rem;
 }
 
 #write > ul:first-child,


### PR DESCRIPTION
As you can see on this screenshot there is an indention bug when the line gets longer, which is fixed by this PR:

![screenshot](https://user-images.githubusercontent.com/2056876/76860355-2c229d00-685b-11ea-8a44-4ddd6e4e01ad.png)

After the fix:

![screenshot_1](https://user-images.githubusercontent.com/2056876/76860373-35ac0500-685b-11ea-9e85-9a606b4b439f.png)


Also fixes and closes #21 