### PR TITLE
Fixed diagram layout overlap during editing

### DIFF
--- a/vue-dark.css
+++ b/vue-dark.css
@@ -606,6 +606,10 @@ tt {
     padding-bottom: 20px;
 }
 
+.md-diagram-panel {
+    position: static !important;
+}
+
 .sidebar-tabs {
     border-bottom: none;
 }

--- a/vue.css
+++ b/vue.css
@@ -378,6 +378,10 @@ tt {
     background-color: #f8f8f8;
 }
 
+.md-diagram-panel {
+    position: static !important;
+}
+
 #write pre.md-meta-block {
     padding: 1rem;
     font-size: 85%;


### PR DESCRIPTION
The issue happens when editing a digram such as `mermaid` or `flowchart`. I am not sure the best solution just fix it as soon as possible. If you have any better solution it can be just close. Thanks 👍 

![Screen Shot 2020-10-13 at 11 38 18 AM](https://user-images.githubusercontent.com/665690/95812760-aad7ae00-0d48-11eb-9d09-810d6b8b4137.png)
![Screen Shot 2020-10-13 at 11 38 25 AM](https://user-images.githubusercontent.com/665690/95812765-ae6b3500-0d48-11eb-9369-e728b7e657f0.png)
