### PR TITLE
Make scrollbar thumb lighter in darkmode

### DIFF
--- a/vue-dark.css
+++ b/vue-dark.css
@@ -807,3 +807,11 @@ html{
 .ty-preferences .search-hit {
     background: var(--select-text-bg-color)
 }
+
+::-webkit-scrollbar-thumb {
+    background: #ffffff5e;
+}
+
+::-webkit-scrollbar-thumb:active {
+    background: #ffffff9c;
+}


### PR DESCRIPTION
I optimized the color of scrollbar thumb in darkmode.
It will make scrollbar easily distinguishable in dark background.