### PR TITLE
fix `code` font size inside headers for dark theme

### DIFF
--- a/vue-dark.css
+++ b/vue-dark.css
@@ -258,32 +258,32 @@ h6:hover a.anchor {
 
 h1 tt,
 h1 code {
-    font-size: inherit;
+    font-size: inherit !important;
 }
 
 h2 tt,
 h2 code {
-    font-size: inherit;
+    font-size: inherit !important;
 }
 
 h3 tt,
 h3 code {
-    font-size: inherit;
+    font-size: inherit !important;
 }
 
 h4 tt,
 h4 code {
-    font-size: inherit;
+    font-size: inherit !important;
 }
 
 h5 tt,
 h5 code {
-    font-size: inherit;
+    font-size: inherit !important;
 }
 
 h6 tt,
 h6 code {
-    font-size: inherit;
+    font-size: inherit !important;
 }
 
 h1 {


### PR DESCRIPTION
add `!important` to `h* code`